### PR TITLE
Removed `((A ^ B) → (A → B))`

### DIFF
--- a/source/hooo/imply.hooo
+++ b/source/hooo/imply.hooo
@@ -1,3 +1,0 @@
-use hooo;
-(a ^ b);
-sugg ((A ^ B) -> (B -> A));

--- a/source/hooo/lower_true.hooo
+++ b/source/hooo/lower_true.hooo
@@ -1,6 +1,0 @@
-use hooo;
-use imply;
-(x ^ ⊤);
-sugg ((A ^ B) → (B → A));
-sugg ((x ^ ⊤) → (⊤ → x));
-sugg (⊤ → x);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -668,11 +668,6 @@ pub fn hooo_lift_eq_refl() -> Expr {
     eq(eq(A, A), pow(eq(A, A), Tr))
 }
 
-/// `((A ^ B) → (A → B))`.
-pub fn hooo_imply() -> Expr {
-    imply(pow(A, B), imply(B, A))
-}
-
 /// `X^X = ⊤`.
 pub fn hooo_refl() -> Expr {
     eq(pow(X, X), Tr)

--- a/src/tactic.rs
+++ b/src/tactic.rs
@@ -124,8 +124,6 @@ pub enum Rule {
     HoooWave,
     /// Hooo false from true.
     HoooFalseFromTrue,
-    /// Hooo imply.
-    HoooImply,
     /// Hooo lift equality reflexivity.
     HoooLiftEqualityReflexivity,
     /// Symmetry equality.
@@ -231,7 +229,6 @@ impl Rule {
             HoooWaveAndOr |
             HoooWave |
             HoooFalseFromTrue |
-            HoooImply |
             HoooLiftEqualityReflexivity => Hooo,
             SymmetryEquality |
             SymmetryAnd |
@@ -825,7 +822,6 @@ impl Tactic {
                             if let Expr::Bin(_) = exp {
                                 add(hooo_dual(), HoooDual);
                             }
-                            add(hooo_imply(), HoooImply);
                         }
                     }
 

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -42,10 +42,8 @@ fn test_sources() {
     assert_eq!(0, check_file("source/hooo/imply_right.hooo").unwrap());
     assert_eq!(0, check_file("source/hooo/imply_left.hooo").unwrap());
     assert_eq!(0, check_file("source/hooo/false_from_true.hooo").unwrap());
-    assert_eq!(0, check_file("source/hooo/lower_true.hooo").unwrap());
-    assert_eq!(0, check_file("source/hooo/imply.hooo").unwrap());
     assert_eq!(0, check_file("source/hooo/lift_eq_refl.hooo").unwrap());
-    assert_eq!(3, check_file("source/hooo/higher_order_lift_eq_refl.hooo").unwrap());
+    assert_eq!(2, check_file("source/hooo/higher_order_lift_eq_refl.hooo").unwrap());
     assert_eq!(0, check_file("source/qubit/subst.hooo").unwrap());
     assert_eq!(0, check_file("source/qubit/to_qual.hooo").unwrap());
     assert_eq!(8, check_file("source/qubit/qual_def.hooo").unwrap());


### PR DESCRIPTION
This leaks context to the global environment